### PR TITLE
bugfix wrong function for pageview on thankyou page

### DIFF
--- a/Modules/Core/ViewConfig.php
+++ b/Modules/Core/ViewConfig.php
@@ -70,7 +70,7 @@ class ViewConfig extends ViewConfig_parent
 
         $oUser = $oConfig->getUser();
 
-        $cl         = $this->getTopActionClassName();
+        $cl         = $this->getTopActiveClassName();
         $aPageTypes = [
             "content"  => "cms",
             "details"  => "product",


### PR DESCRIPTION
The function _getTopActionClassName()_ returns "**start**" on the thankyou-page. Replacing it by _getTopActiveClassName()_

![Bildschirmfoto 2023-03-07 um 13 56 05](https://user-images.githubusercontent.com/1853386/223664643-e6855f99-7db7-4e32-abd5-f2fc861df015.png)
