### PR TITLE
MGH-424 easycredit fix: cast oxdesc to string, may be object

### DIFF
--- a/Modules/Application/Model/gtmPayment.php
+++ b/Modules/Application/Model/gtmPayment.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace D3\GoogleAnalytics4\Modules\Application\Model;
 
-
-use OxidEsales\Eshop\Application\Model\Payment;
-use OxidEsales\Eshop\Core\Registry;
-
 class gtmPayment extends gtmPayment_parent
 {
     /**
@@ -15,6 +11,6 @@ class gtmPayment extends gtmPayment_parent
      */
     public function gtmGetSelectedPaymentName() :string
     {
-        return $this->getFieldData('oxpayments__oxdesc')?: 'No payment name available';
+        return (string)$this->getFieldData('oxpayments__oxdesc')?: 'No payment name available';
     }
 }


### PR DESCRIPTION
easycredit payment may return an object here, containing an html image element and a text, which leads to an exception in checkout when coming back from easycredit. The cast to string fixes that.