### PR TITLE
added option to add variants in view_item event

### DIFF
--- a/Application/Controller/Admin/GA4AdminUserInterface_main.php
+++ b/Application/Controller/Admin/GA4AdminUserInterface_main.php
@@ -39,6 +39,7 @@ class GA4AdminUserInterface_main extends \OxidEsales\Eshop\Application\Controlle
             '_blEnableOwnCookieManager',
             '_blEnableMeasurementCapabilities',
             '_blEnableUsercentricsConsentModeApi',
+            '_blViewItemAddVariants',
         ];
 
         foreach ($aCheckBoxParams as $checkBoxName){

--- a/Application/views/admin/de/d3googleanalytics4_lang.php
+++ b/Application/views/admin/de/d3googleanalytics4_lang.php
@@ -120,4 +120,7 @@ Nachher:
 src="{Domain}?id={Container-ID}"
 </code>
                                                                         </pre>',
+    'D3EXTENDEDCONFIG' => 'Erweiterte Konfiguration',
+    'D3VIEWITEMADDVARIANTS' => 'Varianten in view_item Event senden',
+    'D3VIEWITEMADDVARIANTS_HELP' => 'Wenn aktiviert, werden die Varianten des Produktes im view_item Event beim betrachten des Vater-Artikels an Google Analytics gesendet.<br />Dies ist dann notwendig, wenn die Varianten nicht gesondert ausgewählt werden können und direkt von der Seite des Vater-Artikels in den Warenkorb gelegt werden können.',
 );

--- a/Application/views/admin/tpl/d3googleanalytics4_main.tpl
+++ b/Application/views/admin/tpl/d3googleanalytics4_main.tpl
@@ -193,6 +193,22 @@
                     </div>
                 </div>
             </div>
+            <div class="col-6">
+                <div class="card mb-5">
+                    <div class="card-header">
+                        [{oxmultilang ident="D3EXTENDEDCONFIG"}]
+                    </div>
+                    <div class="card-body">
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" value="" name="editval[bool][_blViewItemAddVariants]" [{if $d3ViewObject->d3GetModuleConfigParam('_blViewItemAddVariants')}]checked[{/if}] id="blGA4enab">
+                            <label class="form-check-label" for="flexCheckDefault">
+                                [{oxmultilang ident="D3VIEWITEMADDVARIANTS"}][{oxinputhelp ident="D3VIEWITEMADDVARIANTS_HELP"}]
+                            </label>
+                        </div>
+                    </div>
+                    <button type="submit" name="save" class="btn btn-light" onClick="Javascript:document.d3gtmformedit.fnc.value='save'">[{oxmultilang ident="GENERAL_SAVE"}]</button>
+                </div>
+            </div>
         </div>
     </form>
 </div>

--- a/Application/views/event/view_item.tpl
+++ b/Application/views/event/view_item.tpl
@@ -30,6 +30,25 @@
                                 [{assign var="d3PriceObject" value=$gtmProduct->getPrice()}]
                                 'price': [{$d3PriceObject->getPrice()}]
                             }
+                            [{if $oViewConf->d3GetModuleConfigParam('_blViewItemAddVariants')}],
+                                [{foreach from=$gtmProduct->getVariants() item="oVariant"}]
+                                    , {
+                                        'item_name': '[{$oVariant->getFieldData("oxtitle")}]',
+                                        'item_id': '[{$oVariant->getFieldData("oxartnum")}]',
+                                        'item_brand': '[{if $gtmManufacturer}][{$gtmManufacturer->oxmanufacturers__oxtitle->value}][{/if}]',
+                                        'item_variant': '[{if $oVariant->getFieldData("oxvarselect")}][{$oVariant->getFieldData("oxvarselect")}][{/if}]',
+                                        [{if $gtmCategory}]
+                                            'item_category':  '[{$gtmCategory->getSplitCategoryArray(0, true)}]',
+                                            'item_category_2':'[{$gtmCategory->getSplitCategoryArray(1, true)}]',
+                                            'item_category_3':'[{$gtmCategory->getSplitCategoryArray(2, true)}]',
+                                            'item_category_4':'[{$gtmCategory->getSplitCategoryArray(3, true)}]',
+                                            'item_list_name':'[{$gtmCategory->getSplitCategoryArray()}]',
+                                        [{/if}]
+                                        [{assign var="d3PriceObject" value=$oVariant->getPrice()}]
+                                        'price': [{$d3PriceObject->getPrice()}]
+                                    }
+                                [{/foreach}]
+                            [{/if}]
                         ]
                 }[{if $oViewConf->isDebugModeOn()}],
                 'debug_mode': 'true'


### PR DESCRIPTION
Added an option to the config page. 
When enabled, the variants of the product will be sent to Google Analytics in the view_item event when viewing the parent item. This is necessary if the variants cannot be selected separately and can be added to the cart directly from the parent item's page.