### PR TITLE
Add missing semikolon to prevent javascript errors

### DIFF
--- a/Application/views/event/purchase.tpl
+++ b/Application/views/event/purchase.tpl
@@ -49,7 +49,7 @@
                 }[{if $oViewConf->isDebugModeOn()}],
                 'debug_mode': 'true'
                 [{/if}]
-            })
+            });
         [{/strip}]
     [{/capture}]
     [{oxscript add=$smarty.capture.d3_ga4_purchase}]


### PR DESCRIPTION
There is a ; missing for a "dataLayer.push()" call. In some cases this causes a Javascript error ("dataLayer.push(...) is not a function"), depending on the scripts loaded on the page and the order of loading.