### PR TITLE
Add item_oxid parameter to all event templates

### DIFF
--- a/Application/views/event/add_payment_info.tpl
+++ b/Application/views/event/add_payment_info.tpl
@@ -26,6 +26,7 @@
                     [{assign var="gtmBasketItem" value=$basketitem->getArticle()}]
                     [{assign var="gtmBasketItemCategory" value=$gtmBasketItem->getCategory()}]
                     {
+                    'item_oxid':        '[{$gtmCartArticles[$basketindex]->getFieldData('oxid')}]',
                     'item_id':          '[{$gtmCartArticles[$basketindex]->getFieldData('oxartnum')}]',
                     'item_name':        '[{$gtmCartArticles[$basketindex]->getFieldData('oxtitle')}]',
                     'item_variant':     '[{$gtmCartArticles[$basketindex]->getFieldData('oxvarselect')}]',

--- a/Application/views/event/add_to_cart.tpl
+++ b/Application/views/event/add_to_cart.tpl
@@ -35,6 +35,7 @@
           'value':      iArtQuantity*[{$d3PriceObject->getPrice()}],
           'items':      [
             {
+              'item_oxid':      '[{$oGtmProduct->getFieldData('oxid')}]',
               'item_id':        '[{$oGtmProduct->getFieldData('oxartnum')}]',
               'item_name':      '[{$oGtmProduct->getFieldData('oxtitle')}]',
               [{oxhasrights ident="SHOWARTICLEPRICE"}]'price':          [{$d3PriceObject->getPrice()}],[{/oxhasrights}]

--- a/Application/views/event/begin_checkout.tpl
+++ b/Application/views/event/begin_checkout.tpl
@@ -25,6 +25,7 @@
             [{assign var="gtmBasketItem" value=$basketitem->getArticle()}]
             [{assign var="gtmBasketItemCategory" value=$gtmBasketItem->getCategory()}]
             {
+            'item_oxid':        '[{$gtmCartArticles[$basketindex]->getFieldData('oxid')}]',
             'item_id':          '[{$gtmCartArticles[$basketindex]->getFieldData('oxartnum')}]',
             'item_name':        '[{$gtmCartArticles[$basketindex]->getFieldData('oxtitle')}]',
             'item_variant':     '[{$gtmCartArticles[$basketindex]->getFieldData('oxvarselect')}]',

--- a/Application/views/event/purchase.tpl
+++ b/Application/views/event/purchase.tpl
@@ -28,6 +28,7 @@
                         [{assign var="gtmPurchaseItemCategory"      value=$gtmPurchaseItem->getCategory()}]
 
                         {
+                            'item_oxid':        '[{$gtmBasketItem->getFieldData("oxid")}]',
                             'item_id':          '[{$gtmBasketItem->getFieldData("oxartnum")}]',
                             'item_name':        '[{$gtmBasketItem->getFieldData("oxtitle")}]',
                             'affiliation':      '[{$gtmBasketItem->getFieldData("oxtitle")}]',

--- a/Application/views/event/remove_from_cart.tpl
+++ b/Application/views/event/remove_from_cart.tpl
@@ -18,6 +18,7 @@
                             [{assign var="d3oItemPrice" value=$rmItem->getPrice()}]
                             [{assign var="gtmBasketItemCategory" value=$rmItem->getCategory()}]
                             {
+                            'item_oxid':        '[{$rmItem->getFieldData('oxid')}]',
                             'item_id':          '[{$rmItem->getFieldData('oxartnum')}]',
                             'item_name':        '[{$rmItem->getFieldData('oxtitle')}]',
                             'item_variant':     '[{$rmItem->getFieldData('oxvarselect')}]',

--- a/Application/views/event/view_cart.tpl
+++ b/Application/views/event/view_cart.tpl
@@ -23,6 +23,7 @@
                         [{assign var="gtmBasketItem" value=$basketitem->getArticle()}]
                         [{assign var="gtmBasketItemCategory" value=$gtmBasketItem->getCategory()}]
                         {
+                            'item_oxid':        '[{$gtmCartArticles[$basketindex]->getFieldData('oxid')}]',
                             'item_id':          '[{$gtmCartArticles[$basketindex]->getFieldData('oxartnum')}]',
                             'item_name':        '[{$gtmCartArticles[$basketindex]->getFieldData('oxtitle')}]',
                             'item_variant':     '[{$gtmCartArticles[$basketindex]->getFieldData('oxvarselect')}]',

--- a/Application/views/event/view_item.tpl
+++ b/Application/views/event/view_item.tpl
@@ -15,6 +15,7 @@
                     'items':
                         [
                             {
+                                'item_oxid': '[{$gtmProduct->getFieldData("oxid")}]',
                                 'item_name': '[{$gtmProduct->getFieldData("oxtitle")}]',
                                 'item_id': '[{$gtmProduct->getFieldData("oxartnum")}]',
                                 'item_brand': '[{if $gtmManufacturer}][{$gtmManufacturer->oxmanufacturers__oxtitle->value}][{/if}]',

--- a/Application/views/event/view_item_list.tpl
+++ b/Application/views/event/view_item_list.tpl
@@ -20,6 +20,7 @@
                             [{assign var="gtmManufacturer" value=$gtmProduct->getManufacturer()}]
                             [{if !$gtmCategory}][{assign var="gtmCategory" value=$gtmProduct->getCategory()}][{/if}]
                             {
+                                'item_oxid': '[{$gtmProduct->getFieldData("oxid")}]',
                                 'item_id': '[{$gtmProduct->getFieldData("oxartnum")}]',
                                 'item_name': '[{$gtmProduct->getFieldData("oxtitle")}]',
                                 [{oxhasrights ident="SHOWARTICLEPRICE"}]'price': [{$d3PriceObject->getPrice()}],[{/oxhasrights}]

--- a/Application/views/event/view_search_result.tpl
+++ b/Application/views/event/view_search_result.tpl
@@ -16,6 +16,7 @@
               [{assign var="gtmManufacturer" value=$gtmProduct->getManufacturer()}]
               [{assign var="gtmCategory" value=$gtmProduct->getCategory()}]
               {
+                'item_oxid': '[{$gtmProduct->getFieldData("oxid")}]',
                 'item_id': '[{$gtmProduct->getFieldData("oxartnum")}]',
                 'item_name': '[{$gtmProduct->getFieldData("oxtitle")}]',
                 [{oxhasrights ident="SHOWARTICLEPRICE"}]'price': [{$d3PriceObject->getPrice()}],[{/oxhasrights}]


### PR DESCRIPTION
For some tracking providers, it is helpful to have the item "oxid" in the transferred data, too. Added param "item_oxid" to all event templates